### PR TITLE
Update 4 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Platform.LocalConfig.nuspec
+++ b/MakoIoT.Device.Platform.LocalConfig.nuspec
@@ -19,12 +19,12 @@
     <dependencies>
       <dependency id="MakoIoT.Device.Platform.Interface" version="1.0.1.28390" />
       <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.31.51806" />
-      <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.30.32136" />
+      <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.32.47509" />
       <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.49.26365" />
-      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.0.30.57507" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.36.21434" />
+      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.0.32.26970" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.38.18612" />
       <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.31.54540" />
-      <dependency id="MakoIoT.Device.Services.Server" version="1.0.34.13996" />
+      <dependency id="MakoIoT.Device.Services.Server" version="1.0.36.59884" />
       <dependency id="MakoIoT.Device.Services.WiFi" version="1.0.35.20139" />
       <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.36.4164" />
       <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.24.34787" />

--- a/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
+++ b/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
@@ -41,24 +41,27 @@
     <Reference Include="MakoIoT.Device.Services.Configuration">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.31.51806\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="MakoIoT.Device.Services.Configuration.Metadata">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.30.32136\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Services.Configuration.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.32.47509\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.ConfigurationManager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.49.26365\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="MakoIoT.Device.Services.FileStorage">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.30.57507\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Services.FileStorage, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.32.26970\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="MakoIoT.Device.Services.Interface">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.36.21434\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+    <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.38.18612\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Mediator">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.31.54540\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.34.13996\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.36.59884\lib\MakoIoT.Device.Services.Server.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi">

--- a/src/MakoIoT.Device.Platform.LocalConfig/packages.config
+++ b/src/MakoIoT.Device.Platform.LocalConfig/packages.config
@@ -2,12 +2,12 @@
 <packages>
   <package id="MakoIoT.Device.Platform.Interface" version="1.0.1.28390" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Configuration" version="1.0.31.51806" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.30.32136" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.32.47509" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.49.26365" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.30.57507" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.36.21434" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.32.26970" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.38.18612" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Mediator" version="1.0.31.54540" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.34.13996" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.36.59884" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.WiFi" version="1.0.35.20139" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.36.4164" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.24.34787" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Configuration.Metadata from 1.0.30.32136 to 1.0.32.47509</br>Bumps MakoIoT.Device.Services.FileStorage from 1.0.30.57507 to 1.0.32.26970</br>Bumps MakoIoT.Device.Services.Interface from 1.0.36.21434 to 1.0.38.18612</br>Bumps MakoIoT.Device.Services.Server from 1.0.34.13996 to 1.0.36.59884</br>
[version update]

### :warning: This is an automated update. :warning:
