### PR TITLE
Update 4 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Platform.LocalConfig.nuspec
+++ b/MakoIoT.Device.Platform.LocalConfig.nuspec
@@ -20,10 +20,10 @@
       <dependency id="MakoIoT.Device.Platform.Interface" version="1.0.5.23338" />
       <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.33.44373" />
       <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.36.60910" />
-      <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.52.48346" />
-      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.0.36.48099" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.41.25178" />
-      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.33.12388" />
+      <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.53.18960" />
+      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.0.37.25" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.42.48151" />
+      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.34.61610" />
       <dependency id="MakoIoT.Device.Services.Server" version="1.0.40.55148" />
       <dependency id="MakoIoT.Device.Services.WiFi" version="1.0.37.1748" />
       <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.39.20890" />

--- a/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
+++ b/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
@@ -49,19 +49,19 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.ConfigurationManager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.52.48346\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.53.18960\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.FileStorage, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.36.48099\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.37.25\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.41.25178\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.42.48151\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Mediator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.33.12388\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.34.61610\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">

--- a/src/MakoIoT.Device.Platform.LocalConfig/packages.config
+++ b/src/MakoIoT.Device.Platform.LocalConfig/packages.config
@@ -3,10 +3,10 @@
   <package id="MakoIoT.Device.Platform.Interface" version="1.0.5.23338" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Configuration" version="1.0.33.44373" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.36.60910" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.52.48346" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.36.48099" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.41.25178" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Mediator" version="1.0.33.12388" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.53.18960" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.37.25" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.42.48151" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Mediator" version="1.0.34.61610" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Server" version="1.0.40.55148" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.WiFi" version="1.0.37.1748" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.39.20890" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.ConfigurationManager from 1.0.52.48346 to 1.0.53.18960</br>Bumps MakoIoT.Device.Services.FileStorage from 1.0.36.48099 to 1.0.37.25</br>Bumps MakoIoT.Device.Services.Interface from 1.0.41.25178 to 1.0.42.48151</br>Bumps MakoIoT.Device.Services.Mediator from 1.0.33.12388 to 1.0.34.61610</br>
[version update]

### :warning: This is an automated update. :warning:
