### PR TITLE
Update 6 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Platform.LocalConfig.nuspec
+++ b/MakoIoT.Device.Platform.LocalConfig.nuspec
@@ -18,15 +18,15 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot platform device configuration ap webserver</tags>
     <dependencies>
       <dependency id="MakoIoT.Device.Platform.Interface" version="1.0.5.23338" />
-      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.33.44373" />
-      <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.36.60910" />
-      <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.53.18960" />
+      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.34.49211" />
+      <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.37.7400" />
+      <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.55.30991" />
       <dependency id="MakoIoT.Device.Services.FileStorage" version="1.0.37.25" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.42.48151" />
       <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.34.61610" />
-      <dependency id="MakoIoT.Device.Services.Server" version="1.0.40.55148" />
-      <dependency id="MakoIoT.Device.Services.WiFi" version="1.0.37.1748" />
-      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.39.20890" />
+      <dependency id="MakoIoT.Device.Services.Server" version="1.0.41.16888" />
+      <dependency id="MakoIoT.Device.Services.WiFi" version="1.0.39.52460" />
+      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.41.22773" />
       <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.27.50780" />
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.33.52014" />
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />

--- a/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
+++ b/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
@@ -41,15 +41,15 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.33.44373\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.34.49211\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.36.60910\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.37.7400\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.ConfigurationManager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.53.18960\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.55.30991\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.FileStorage, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -65,15 +65,15 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.40.55148\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.41.16888\lib\MakoIoT.Device.Services.Server.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.1.0.37.1748\lib\MakoIoT.Device.Services.WiFi.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.1.0.39.52460\lib\MakoIoT.Device.Services.WiFi.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.39.20890\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.41.22773\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">

--- a/src/MakoIoT.Device.Platform.LocalConfig/packages.config
+++ b/src/MakoIoT.Device.Platform.LocalConfig/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Platform.Interface" version="1.0.5.23338" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Configuration" version="1.0.33.44373" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.36.60910" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.53.18960" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration" version="1.0.34.49211" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.37.7400" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.55.30991" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.FileStorage" version="1.0.37.25" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.42.48151" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Mediator" version="1.0.34.61610" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.40.55148" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi" version="1.0.37.1748" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.39.20890" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.41.16888" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi" version="1.0.39.52460" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.41.22773" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.27.50780" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.33.52014" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Configuration from 1.0.33.44373 to 1.0.34.49211</br>Bumps MakoIoT.Device.Services.Configuration.Metadata from 1.0.36.60910 to 1.0.37.7400</br>Bumps MakoIoT.Device.Services.ConfigurationManager from 1.0.53.18960 to 1.0.55.30991</br>Bumps MakoIoT.Device.Services.Server from 1.0.40.55148 to 1.0.41.16888</br>Bumps MakoIoT.Device.Services.WiFi from 1.0.37.1748 to 1.0.39.52460</br>Bumps MakoIoT.Device.Services.WiFi.AP from 1.0.39.20890 to 1.0.41.22773</br>
[version update]

### :warning: This is an automated update. :warning:
