### PR TITLE
Update 14 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Platform.LocalConfig.nuspec
+++ b/MakoIoT.Device.Platform.LocalConfig.nuspec
@@ -18,30 +18,30 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot platform device configuration ap webserver</tags>
     <dependencies>
       <dependency id="MakoIoT.Device.Platform.Interface" version="1.0.9.33126" />
-      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.42.31032" />
+      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.43.25265" />
       <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.43.32843" />
-      <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.84.14356" />
-      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.0.48.43713" />
+      <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.85.63996" />
+      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.0.49.32114" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" />
-      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.41.33870" />
-      <dependency id="MakoIoT.Device.Services.Server" version="1.0.55.18882" />
-      <dependency id="MakoIoT.Device.Services.WiFi" version="1.0.55.21361" />
-      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.58.16345" />
-      <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.28.14340" />
+      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.42.48945" />
+      <dependency id="MakoIoT.Device.Services.Server" version="1.0.56.27774" />
+      <dependency id="MakoIoT.Device.Services.WiFi" version="1.0.56.50928" />
+      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.59.43903" />
+      <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.29.40293" />
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.33.52014" />
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.3" />
       <dependency id="nanoFramework.Iot.Device.DhcpServer" version="1.2.454" />
-      <dependency id="nanoFramework.Json" version="2.2.113" />
-      <dependency id="nanoFramework.Logging" version="1.1.88" />
+      <dependency id="nanoFramework.Json" version="2.2.117" />
+      <dependency id="nanoFramework.Logging" version="1.1.92" />
       <dependency id="nanoFramework.ResourceManager" version="1.2.19" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.15" />
       <dependency id="nanoFramework.System.Collections" version="1.5.31" />
-      <dependency id="nanoFramework.System.Device.Wifi" version="1.5.79" />
+      <dependency id="nanoFramework.System.Device.Wifi" version="1.5.81" />
       <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.36" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.56" />
-      <dependency id="nanoFramework.System.Net" version="1.10.75" />
-      <dependency id="nanoFramework.System.Net.Http" version="1.5.132" />
+      <dependency id="nanoFramework.System.IO.Streams" version="1.1.59" />
+      <dependency id="nanoFramework.System.Net" version="1.10.77" />
+      <dependency id="nanoFramework.System.Net.Http" version="1.5.134" />
       <dependency id="nanoFramework.System.Text" version="1.2.54" />
       <dependency id="nanoFramework.System.Threading" version="1.1.32" />
     </dependencies>

--- a/Tests/SoftwareTests/MakoIoT.Device.Platform.LocalConfig.Test/MakoIoT.Device.Platform.LocalConfig.Test.nfproj
+++ b/Tests/SoftwareTests/MakoIoT.Device.Platform.LocalConfig.Test/MakoIoT.Device.Platform.LocalConfig.Test.nfproj
@@ -57,16 +57,16 @@
       <HintPath>..\..\..\packages\nanoFramework.TestFramework.2.1.94\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.Streams, Version=1.1.56.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.IO.Streams.1.1.56\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.System.IO.Streams.1.1.59\lib\System.IO.Streams.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net, Version=1.10.75.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Net.1.10.75\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.10.77.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.System.Net.1.10.77\lib\System.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.132.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Net.Http.1.5.132\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.134.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.System.Net.Http.1.5.134\lib\System.Net.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.32.63105, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/Tests/SoftwareTests/MakoIoT.Device.Platform.LocalConfig.Test/packages.config
+++ b/Tests/SoftwareTests/MakoIoT.Device.Platform.LocalConfig.Test/packages.config
@@ -3,9 +3,9 @@
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.15" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.56" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.10.75" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.132" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.59" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.10.77" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.134" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.TestFramework" version="2.1.94" targetFramework="netnano1.0" developmentDependency="true" />

--- a/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
+++ b/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
@@ -41,7 +41,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.42.31032\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.43.25265\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -49,11 +49,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.ConfigurationManager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.84.14356\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.85.63996\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.FileStorage, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.48.43713\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.49.32114\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -61,23 +61,23 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Mediator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.41.33870\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.42.48945\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.55.18882\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.56.27774\lib\MakoIoT.Device.Services.Server.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.1.0.55.21361\lib\MakoIoT.Device.Services.WiFi.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.1.0.56.50928\lib\MakoIoT.Device.Services.WiFi.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.58.16345\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.59.43903\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.28.14340\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.29.40293\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.String, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -92,12 +92,12 @@
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.3\lib\nanoFramework.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Json, Version=2.2.113.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Json.2.2.113\lib\nanoFramework.Json.dll</HintPath>
+    <Reference Include="nanoFramework.Json, Version=2.2.117.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Json.2.2.117\lib\nanoFramework.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Logging, Version=1.1.88.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Logging.1.1.88\lib\nanoFramework.Logging.dll</HintPath>
+    <Reference Include="nanoFramework.Logging, Version=1.1.92.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Logging.1.1.92\lib\nanoFramework.Logging.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.ResourceManager, Version=1.2.19.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
@@ -120,24 +120,24 @@
       <HintPath>..\..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Device.Wifi, Version=1.5.79.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Device.Wifi.1.5.79\lib\System.Device.Wifi.dll</HintPath>
+    <Reference Include="System.Device.Wifi, Version=1.5.81.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Device.Wifi.1.5.81\lib\System.Device.Wifi.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.IO.FileSystem, Version=1.1.36.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.IO.FileSystem.1.1.36\lib\System.IO.FileSystem.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.Streams, Version=1.1.56.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.56\lib\System.IO.Streams.dll</HintPath>
+    <Reference Include="System.IO.Streams, Version=1.1.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.59\lib\System.IO.Streams.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net, Version=1.10.75.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.1.10.75\lib\System.Net.dll</HintPath>
+    <Reference Include="System.Net, Version=1.10.77.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.1.10.77\lib\System.Net.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.132.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.132\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.134.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.134\lib\System.Net.Http.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.32.63105, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/src/MakoIoT.Device.Platform.LocalConfig/packages.config
+++ b/src/MakoIoT.Device.Platform.LocalConfig/packages.config
@@ -1,30 +1,30 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Platform.Interface" version="1.0.9.33126" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Configuration" version="1.0.42.31032" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration" version="1.0.43.25265" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.43.32843" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.84.14356" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.48.43713" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.85.63996" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.49.32114" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Mediator" version="1.0.41.33870" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.55.18882" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi" version="1.0.55.21361" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.58.16345" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.28.14340" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Mediator" version="1.0.42.48945" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.56.27774" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi" version="1.0.56.50928" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.59.43903" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.29.40293" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.33.52014" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
   <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.454" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Json" version="2.2.113" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Logging" version="1.1.88" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Json" version="2.2.117" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Logging" version="1.1.92" targetFramework="netnano1.0" />
   <package id="nanoFramework.ResourceManager" version="1.2.19" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.15" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Device.Wifi" version="1.5.79" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Device.Wifi" version="1.5.81" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.FileSystem" version="1.1.36" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.Streams" version="1.1.56" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net" version="1.10.75" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.132" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.Streams" version="1.1.59" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net" version="1.10.77" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.134" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Runtime" version="1.0.6" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Configuration from 1.0.42.31032 to 1.0.43.25265</br>Bumps MakoIoT.Device.Services.ConfigurationManager from 1.0.84.14356 to 1.0.85.63996</br>Bumps MakoIoT.Device.Services.FileStorage from 1.0.48.43713 to 1.0.49.32114</br>Bumps MakoIoT.Device.Services.Mediator from 1.0.41.33870 to 1.0.42.48945</br>Bumps MakoIoT.Device.Services.Server from 1.0.55.18882 to 1.0.56.27774</br>Bumps MakoIoT.Device.Services.WiFi from 1.0.55.21361 to 1.0.56.50928</br>Bumps MakoIoT.Device.Services.WiFi.AP from 1.0.58.16345 to 1.0.59.43903</br>Bumps MakoIoT.Device.Utilities.Invoker from 1.0.28.14340 to 1.0.29.40293</br>Bumps nanoFramework.Json from 2.2.113 to 2.2.117</br>Bumps nanoFramework.Logging from 1.1.88 to 1.1.92</br>Bumps nanoFramework.System.Device.Wifi from 1.5.79 to 1.5.81</br>Bumps nanoFramework.System.IO.Streams from 1.1.56 to 1.1.59</br>Bumps nanoFramework.System.Net from 1.10.75 to 1.10.77</br>Bumps nanoFramework.System.Net.Http from 1.5.132 to 1.5.134</br>
[version update]

### :warning: This is an automated update. :warning:
