### PR TITLE
Update 6 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Platform.LocalConfig.nuspec
+++ b/MakoIoT.Device.Platform.LocalConfig.nuspec
@@ -18,17 +18,17 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot platform device configuration ap webserver</tags>
     <dependencies>
       <dependency id="MakoIoT.Device.Platform.Interface" version="1.0.12.12799" />
-      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.46.22575" />
-      <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.43.32843" />
+      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.47.11163" />
+      <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.44.44267" />
       <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.97.30659" />
-      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.0.57.49182" />
+      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.0.59.27693" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" />
       <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.43.57607" />
       <dependency id="MakoIoT.Device.Services.Server" version="1.0.59.19469" />
       <dependency id="MakoIoT.Device.Services.WiFi" version="1.0.59.6363" />
       <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.65.51942" />
       <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.30.23980" />
-      <dependency id="MakoIoT.Device.Utilities.String" version="1.0.33.52014" />
+      <dependency id="MakoIoT.Device.Utilities.String" version="1.0.34.50886" />
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.3" />
       <dependency id="nanoFramework.Iot.Device.DhcpServer" version="1.2.519" />

--- a/Tests/SoftwareTests/MakoIoT.Device.Platform.LocalConfig.Test/MakoIoT.Device.Platform.LocalConfig.Test.nfproj
+++ b/Tests/SoftwareTests/MakoIoT.Device.Platform.LocalConfig.Test/MakoIoT.Device.Platform.LocalConfig.Test.nfproj
@@ -49,12 +49,12 @@
       <HintPath>..\..\..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=2.1.104.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.TestFramework.2.1.104\lib\nanoFramework.TestFramework.dll</HintPath>
+    <Reference Include="nanoFramework.TestFramework, Version=2.1.107.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.TestFramework.2.1.107\lib\nanoFramework.TestFramework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.TestFramework.2.1.104\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
+      <HintPath>..\..\..\packages\nanoFramework.TestFramework.2.1.107\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.IO.Streams, Version=1.1.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">

--- a/Tests/SoftwareTests/MakoIoT.Device.Platform.LocalConfig.Test/packages.config
+++ b/Tests/SoftwareTests/MakoIoT.Device.Platform.LocalConfig.Test/packages.config
@@ -8,5 +8,5 @@
   <package id="nanoFramework.System.Net.Http" version="1.5.138" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="2.1.104" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="nanoFramework.TestFramework" version="2.1.107" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>

--- a/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
+++ b/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.props" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.props')" />
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
   </PropertyGroup>
@@ -41,11 +42,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.46.22575\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.47.11163\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.43.32843\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.44.44267\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.ConfigurationManager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -53,7 +54,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.FileStorage, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.57.49182\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.59.27693\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
@@ -81,7 +82,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.String, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.33.52014\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.34.50886\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
@@ -174,7 +175,8 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.6.133\build\Nerdbank.GitVersioning.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.6.133\build\Nerdbank.GitVersioning.props'))" />
-    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.6.133\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.6.133\build\Nerdbank.GitVersioning.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.props'))" />
+    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.6.133\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.6.133\build\Nerdbank.GitVersioning.targets')" />
+  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.targets')" />
 </Project>

--- a/src/MakoIoT.Device.Platform.LocalConfig/packages.config
+++ b/src/MakoIoT.Device.Platform.LocalConfig/packages.config
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Platform.Interface" version="1.0.12.12799" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Configuration" version="1.0.46.22575" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.43.32843" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration" version="1.0.47.11163" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.44.44267" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.97.30659" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.57.49182" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.59.27693" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Mediator" version="1.0.43.57607" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Server" version="1.0.59.19469" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.WiFi" version="1.0.59.6363" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.65.51942" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.30.23980" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Utilities.String" version="1.0.33.52014" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Utilities.String" version="1.0.34.50886" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
   <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.519" targetFramework="netnano1.0" />
@@ -28,5 +28,5 @@
   <package id="nanoFramework.System.Runtime" version="1.0.27" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
-  <package id="Nerdbank.GitVersioning" version="3.6.133" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="Nerdbank.GitVersioning" version="3.6.139" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Configuration from 1.0.46.22575 to 1.0.47.11163</br>Bumps MakoIoT.Device.Services.Configuration.Metadata from 1.0.43.32843 to 1.0.44.44267</br>Bumps MakoIoT.Device.Services.FileStorage from 1.0.57.49182 to 1.0.59.27693</br>Bumps MakoIoT.Device.Utilities.String from 1.0.33.52014 to 1.0.34.50886</br>Bumps Nerdbank.GitVersioning from 3.6.133 to 3.6.139</br>Bumps nanoFramework.TestFramework from 2.1.104 to 2.1.107</br>
[version update]

### :warning: This is an automated update. :warning:
