### PR TITLE
Update 15 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Platform.LocalConfig.nuspec
+++ b/MakoIoT.Device.Platform.LocalConfig.nuspec
@@ -18,27 +18,27 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot platform device configuration ap webserver</tags>
     <dependencies>
       <dependency id="MakoIoT.Device.Platform.Interface" version="1.0.12.12799" />
-      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.46.22575" />
-      <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.43.32843" />
-      <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.97.30659" />
-      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.0.57.49182" />
+      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.47.11163" />
+      <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.44.44267" />
+      <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.101.43237" />
+      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.0.60.23874" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" />
-      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.43.57607" />
-      <dependency id="MakoIoT.Device.Services.Server" version="1.0.59.19469" />
-      <dependency id="MakoIoT.Device.Services.WiFi" version="1.0.59.6363" />
-      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.65.51942" />
-      <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.30.23980" />
-      <dependency id="MakoIoT.Device.Utilities.String" version="1.0.33.52014" />
+      <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.44.7886" />
+      <dependency id="MakoIoT.Device.Services.Server" version="1.0.60.49115" />
+      <dependency id="MakoIoT.Device.Services.WiFi" version="1.0.60.19597" />
+      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.68.7317" />
+      <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.31.7929" />
+      <dependency id="MakoIoT.Device.Utilities.String" version="1.0.34.50886" />
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.3" />
-      <dependency id="nanoFramework.Iot.Device.DhcpServer" version="1.2.519" />
+      <dependency id="nanoFramework.Iot.Device.DhcpServer" version="1.2.541" />
       <dependency id="nanoFramework.Json" version="2.2.122" />
-      <dependency id="nanoFramework.Logging" version="1.1.100" />
+      <dependency id="nanoFramework.Logging" version="1.1.107" />
       <dependency id="nanoFramework.ResourceManager" version="1.2.19" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.18" />
       <dependency id="nanoFramework.System.Collections" version="1.5.31" />
       <dependency id="nanoFramework.System.Device.Wifi" version="1.5.85" />
-      <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.47" />
+      <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.54" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.59" />
       <dependency id="nanoFramework.System.Net" version="1.10.79" />
       <dependency id="nanoFramework.System.Net.Http" version="1.5.138" />

--- a/Tests/SoftwareTests/MakoIoT.Device.Platform.LocalConfig.Test/MakoIoT.Device.Platform.LocalConfig.Test.nfproj
+++ b/Tests/SoftwareTests/MakoIoT.Device.Platform.LocalConfig.Test/MakoIoT.Device.Platform.LocalConfig.Test.nfproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
@@ -35,43 +35,33 @@
   <ItemGroup>
     <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.11.18.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\..\packages\nanoFramework.Runtime.Events.1.11.18\lib\nanoFramework.Runtime.Events.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Collections, Version=1.5.31.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\..\packages\nanoFramework.System.Collections.1.5.31\lib\nanoFramework.System.Collections.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.2.54.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.TestFramework, Version=2.1.104.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.TestFramework.2.1.104\lib\nanoFramework.TestFramework.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nanoFramework.TestFramework, Version=2.1.107.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.TestFramework.2.1.107\lib\nanoFramework.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.UnitTestLauncher, Version=0.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.TestFramework.2.1.104\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\..\packages\nanoFramework.TestFramework.2.1.107\lib\nanoFramework.UnitTestLauncher.exe</HintPath>
     </Reference>
     <Reference Include="System.IO.Streams, Version=1.1.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\..\packages\nanoFramework.System.IO.Streams.1.1.59\lib\System.IO.Streams.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.Net, Version=1.10.79.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\..\packages\nanoFramework.System.Net.1.10.79\lib\System.Net.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http, Version=1.5.138.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\..\packages\nanoFramework.System.Net.Http.1.5.138\lib\System.Net.Http.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.32.63105, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\..\packages\nanoFramework.System.Threading.1.1.32\lib\System.Threading.dll</HintPath>
-      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Tests/SoftwareTests/MakoIoT.Device.Platform.LocalConfig.Test/packages.config
+++ b/Tests/SoftwareTests/MakoIoT.Device.Platform.LocalConfig.Test/packages.config
@@ -8,5 +8,5 @@
   <package id="nanoFramework.System.Net.Http" version="1.5.138" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
-  <package id="nanoFramework.TestFramework" version="2.1.104" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="nanoFramework.TestFramework" version="2.1.107" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>

--- a/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
+++ b/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
@@ -1,5 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.props" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.props')" />
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
   </PropertyGroup>
@@ -33,116 +34,88 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Iot.Device.DhcpServer, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Iot.Device.DhcpServer.1.2.519\lib\Iot.Device.DhcpServer.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\nanoFramework.Iot.Device.DhcpServer.1.2.541\lib\Iot.Device.DhcpServer.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Platform.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Platform.Interface.1.0.12.12799\lib\MakoIoT.Device.Platform.Interface.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.46.22575\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.47.11163\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.43.32843\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.44.44267\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.ConfigurationManager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.97.30659\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.101.43237\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.FileStorage, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.57.49182\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.0.60.23874\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.46.2905\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Mediator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.43.57607\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.44.7886\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.59.19469\lib\MakoIoT.Device.Services.Server.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.60.49115\lib\MakoIoT.Device.Services.Server.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.1.0.59.6363\lib\MakoIoT.Device.Services.WiFi.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.1.0.60.19597\lib\MakoIoT.Device.Services.WiFi.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.65.51942\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.68.7317\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.30.23980\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.31.7929\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.String, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.33.52014\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\MakoIoT.Device.Utilities.String.1.0.34.50886\lib\MakoIoT.Device.Utilities.String.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.3\lib\nanoFramework.DependencyInjection.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Json, Version=2.2.122.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Json.2.2.122\lib\nanoFramework.Json.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.Logging, Version=1.1.100.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Logging.1.1.100\lib\nanoFramework.Logging.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="nanoFramework.Logging, Version=1.1.107.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Logging.1.1.107\lib\nanoFramework.Logging.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.ResourceManager, Version=1.2.19.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.ResourceManager.1.2.19\lib\nanoFramework.ResourceManager.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.11.18.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.18\lib\nanoFramework.Runtime.Events.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Collections, Version=1.5.31.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.31\lib\nanoFramework.System.Collections.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Runtime, Version=1.0.27.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Runtime.1.0.27\lib\nanoFramework.System.Runtime.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.2.54.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Text.1.2.54\lib\nanoFramework.System.Text.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.Device.Wifi, Version=1.5.85.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Device.Wifi.1.5.85\lib\System.Device.Wifi.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="System.IO.FileSystem, Version=1.1.47.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.FileSystem.1.1.47\lib\System.IO.FileSystem.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.IO.FileSystem, Version=1.1.54.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.FileSystem.1.1.54\lib\System.IO.FileSystem.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Streams, Version=1.1.59.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.59\lib\System.IO.Streams.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.Net, Version=1.10.79.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Net.1.10.79\lib\System.Net.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http, Version=1.5.138.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.138\lib\System.Net.Http.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.32.63105, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.32\lib\System.Threading.dll</HintPath>
-      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -174,7 +147,8 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105.The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.6.133\build\Nerdbank.GitVersioning.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.6.133\build\Nerdbank.GitVersioning.props'))" />
-    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.6.133\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.6.133\build\Nerdbank.GitVersioning.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.props'))" />
+    <Error Condition="!Exists('..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.targets'))" />
   </Target>
-  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.6.133\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.6.133\build\Nerdbank.GitVersioning.targets')" />
+  <Import Project="..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\..\packages\Nerdbank.GitVersioning.3.6.139\build\Nerdbank.GitVersioning.targets')" />
 </Project>

--- a/src/MakoIoT.Device.Platform.LocalConfig/packages.config
+++ b/src/MakoIoT.Device.Platform.LocalConfig/packages.config
@@ -1,32 +1,32 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Platform.Interface" version="1.0.12.12799" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Configuration" version="1.0.46.22575" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.43.32843" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.97.30659" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.57.49182" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration" version="1.0.47.11163" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.44.44267" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.101.43237" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.FileStorage" version="1.0.60.23874" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Mediator" version="1.0.43.57607" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.59.19469" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi" version="1.0.59.6363" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.65.51942" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.30.23980" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Utilities.String" version="1.0.33.52014" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Mediator" version="1.0.44.7886" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.60.49115" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi" version="1.0.60.19597" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.68.7317" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.31.7929" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Utilities.String" version="1.0.34.50886" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.519" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.541" targetFramework="netnano1.0" />
   <package id="nanoFramework.Json" version="2.2.122" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Logging" version="1.1.100" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Logging" version="1.1.107" targetFramework="netnano1.0" />
   <package id="nanoFramework.ResourceManager" version="1.2.19" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.18" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.31" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Device.Wifi" version="1.5.85" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.FileSystem" version="1.1.47" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.FileSystem" version="1.1.54" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.59" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.10.79" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net.Http" version="1.5.138" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Runtime" version="1.0.27" />
   <package id="nanoFramework.System.Text" version="1.2.54" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.32" targetFramework="netnano1.0" />
-  <package id="Nerdbank.GitVersioning" version="3.6.133" targetFramework="netnano1.0" developmentDependency="true" />
+  <package id="Nerdbank.GitVersioning" version="3.6.139" targetFramework="netnano1.0" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Configuration from 1.0.46.22575 to 1.0.47.11163</br>Bumps MakoIoT.Device.Services.Configuration.Metadata from 1.0.43.32843 to 1.0.44.44267</br>Bumps MakoIoT.Device.Services.ConfigurationManager from 1.0.97.30659 to 1.0.101.43237</br>Bumps MakoIoT.Device.Services.FileStorage from 1.0.57.49182 to 1.0.60.23874</br>Bumps MakoIoT.Device.Services.Mediator from 1.0.43.57607 to 1.0.44.7886</br>Bumps MakoIoT.Device.Services.Server from 1.0.59.19469 to 1.0.60.49115</br>Bumps MakoIoT.Device.Services.WiFi from 1.0.59.6363 to 1.0.60.19597</br>Bumps MakoIoT.Device.Services.WiFi.AP from 1.0.65.51942 to 1.0.68.7317</br>Bumps MakoIoT.Device.Utilities.Invoker from 1.0.30.23980 to 1.0.31.7929</br>Bumps MakoIoT.Device.Utilities.String from 1.0.33.52014 to 1.0.34.50886</br>Bumps nanoFramework.Iot.Device.DhcpServer from 1.2.519 to 1.2.541</br>Bumps nanoFramework.Logging from 1.1.100 to 1.1.107</br>Bumps nanoFramework.System.IO.FileSystem from 1.1.47 to 1.1.54</br>Bumps Nerdbank.GitVersioning from 3.6.133 to 3.6.139</br>Bumps nanoFramework.TestFramework from 2.1.104 to 2.1.107</br>
[version update]

### :warning: This is an automated update. :warning:
