### PR TITLE
Update 6 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Platform.LocalConfig.nuspec
+++ b/MakoIoT.Device.Platform.LocalConfig.nuspec
@@ -18,15 +18,15 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot platform device configuration ap webserver</tags>
     <dependencies>
       <dependency id="MakoIoT.Device.Platform.Interface" version="1.0.12.12799" />
-      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.62.51969" />
-      <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.51.20103" />
+      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.64.18364" />
+      <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.52.29017" />
       <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.138.9072" />
-      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.1.1.4387" />
+      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.1.2.5964" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.50.35966" />
       <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.58.36645" />
-      <dependency id="MakoIoT.Device.Services.Server" version="1.0.77.42584" />
-      <dependency id="MakoIoT.Device.Services.WiFi" version="1.0.74.30059" />
-      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.90.47072" />
+      <dependency id="MakoIoT.Device.Services.Server" version="1.0.78.24418" />
+      <dependency id="MakoIoT.Device.Services.WiFi" version="1.0.75.54666" />
+      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.91.55565" />
       <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.42.25254" />
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.38.1040" />
       <dependency id="nanoFramework.CoreLibrary" version="1.16.11" />

--- a/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
+++ b/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
@@ -40,16 +40,16 @@
       <HintPath>..\..\packages\MakoIoT.Device.Platform.Interface.1.0.12.12799\lib\MakoIoT.Device.Platform.Interface.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.62.51969\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.64.18364\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.51.20103\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.52.29017\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.ConfigurationManager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.138.9072\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.FileStorage, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.1.1.4387\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.1.2.5964\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.50.35966\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
@@ -58,13 +58,13 @@
       <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.58.36645\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.77.42584\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.78.24418\lib\MakoIoT.Device.Services.Server.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.1.0.74.30059\lib\MakoIoT.Device.Services.WiFi.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.1.0.75.54666\lib\MakoIoT.Device.Services.WiFi.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.90.47072\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.91.55565\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.42.25254\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>

--- a/src/MakoIoT.Device.Platform.LocalConfig/packages.config
+++ b/src/MakoIoT.Device.Platform.LocalConfig/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Platform.Interface" version="1.0.12.12799" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Configuration" version="1.0.62.51969" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.51.20103" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration" version="1.0.64.18364" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.52.29017" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.138.9072" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.FileStorage" version="1.1.1.4387" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.FileStorage" version="1.1.2.5964" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.50.35966" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Mediator" version="1.0.58.36645" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.77.42584" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi" version="1.0.74.30059" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.90.47072" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.78.24418" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi" version="1.0.75.54666" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.91.55565" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.42.25254" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.38.1040" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.16.11" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Configuration from 1.0.62.51969 to 1.0.64.18364</br>Bumps MakoIoT.Device.Services.Configuration.Metadata from 1.0.51.20103 to 1.0.52.29017</br>Bumps MakoIoT.Device.Services.FileStorage from 1.1.1.4387 to 1.1.2.5964</br>Bumps MakoIoT.Device.Services.Server from 1.0.77.42584 to 1.0.78.24418</br>Bumps MakoIoT.Device.Services.WiFi from 1.0.74.30059 to 1.0.75.54666</br>Bumps MakoIoT.Device.Services.WiFi.AP from 1.0.90.47072 to 1.0.91.55565</br>
[version update]

### :warning: This is an automated update. :warning:
