### PR TITLE
Update 4 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Platform.LocalConfig.nuspec
+++ b/MakoIoT.Device.Platform.LocalConfig.nuspec
@@ -20,25 +20,25 @@
       <dependency id="MakoIoT.Device.Platform.Interface" version="1.0.23.47567" />
       <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.68.40789" />
       <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.56.9205" />
-      <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.147.3685" />
+      <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.148.31705" />
       <dependency id="MakoIoT.Device.Services.FileStorage" version="1.1.7.46290" />
       <dependency id="MakoIoT.Device.Services.Interface" version="1.0.53.21413" />
       <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.61.19880" />
       <dependency id="MakoIoT.Device.Services.Server" version="1.0.83.49925" />
       <dependency id="MakoIoT.Device.Services.WiFi" version="1.0.79.15391" />
-      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.96.14949" />
+      <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.97.55003" />
       <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.44.64291" />
       <dependency id="MakoIoT.Device.Utilities.String" version="1.0.40.2867" />
       <dependency id="nanoFramework.CoreLibrary" version="1.17.1" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.29" />
       <dependency id="nanoFramework.Iot.Device.DhcpServer" version="1.2.809" />
       <dependency id="nanoFramework.Json" version="2.2.185" />
-      <dependency id="nanoFramework.Logging" version="1.1.146" />
+      <dependency id="nanoFramework.Logging" version="1.1.147" />
       <dependency id="nanoFramework.ResourceManager" version="1.2.30" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.30" />
       <dependency id="nanoFramework.System.Collections" version="1.5.62" />
       <dependency id="nanoFramework.System.Device.Wifi" version="1.5.124" />
-      <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.80" />
+      <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.81" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.89" />
       <dependency id="nanoFramework.System.Net" version="1.11.34" />
       <dependency id="nanoFramework.System.Net.Http" version="1.5.184" />

--- a/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
+++ b/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
@@ -46,7 +46,7 @@
       <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.56.9205\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.ConfigurationManager, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.147.3685\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.148.31705\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.FileStorage, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.1.7.46290\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
@@ -64,7 +64,7 @@
       <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.1.0.79.15391\lib\MakoIoT.Device.Services.WiFi.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi.AP, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.96.14949\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.AP.1.0.97.55003\lib\MakoIoT.Device.Services.WiFi.AP.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Utilities.Invoker, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Utilities.Invoker.1.0.44.64291\lib\MakoIoT.Device.Utilities.Invoker.dll</HintPath>
@@ -81,8 +81,8 @@
     <Reference Include="nanoFramework.Json, Version=2.2.185.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Json.2.2.185\lib\nanoFramework.Json.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Logging, Version=1.1.146.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Logging.1.1.146\lib\nanoFramework.Logging.dll</HintPath>
+    <Reference Include="nanoFramework.Logging, Version=1.1.147.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Logging.1.1.147\lib\nanoFramework.Logging.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.ResourceManager, Version=1.2.30.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.ResourceManager.1.2.30\lib\nanoFramework.ResourceManager.dll</HintPath>
@@ -102,8 +102,8 @@
     <Reference Include="System.Device.Wifi, Version=1.5.124.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Device.Wifi.1.5.124\lib\System.Device.Wifi.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.FileSystem, Version=1.1.80.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.IO.FileSystem.1.1.80\lib\System.IO.FileSystem.dll</HintPath>
+    <Reference Include="System.IO.FileSystem, Version=1.1.81.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.IO.FileSystem.1.1.81\lib\System.IO.FileSystem.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Streams, Version=1.1.89.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.IO.Streams.1.1.89\lib\System.IO.Streams.dll</HintPath>

--- a/src/MakoIoT.Device.Platform.LocalConfig/packages.config
+++ b/src/MakoIoT.Device.Platform.LocalConfig/packages.config
@@ -3,25 +3,25 @@
   <package id="MakoIoT.Device.Platform.Interface" version="1.0.23.47567" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Configuration" version="1.0.68.40789" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.56.9205" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.147.3685" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.148.31705" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.FileStorage" version="1.1.7.46290" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Interface" version="1.0.53.21413" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Mediator" version="1.0.61.19880" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Server" version="1.0.83.49925" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.WiFi" version="1.0.79.15391" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.96.14949" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.97.55003" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.44.64291" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.String" version="1.0.40.2867" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.1" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.29" targetFramework="netnano1.0" />
   <package id="nanoFramework.Iot.Device.DhcpServer" version="1.2.809" targetFramework="netnano1.0" />
   <package id="nanoFramework.Json" version="2.2.185" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Logging" version="1.1.146" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Logging" version="1.1.147" targetFramework="netnano1.0" />
   <package id="nanoFramework.ResourceManager" version="1.2.30" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.30" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.62" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Device.Wifi" version="1.5.124" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.IO.FileSystem" version="1.1.80" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.IO.FileSystem" version="1.1.81" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.89" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.11.34" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net.Http" version="1.5.184" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.ConfigurationManager from 1.0.147.3685 to 1.0.148.31705</br>Bumps MakoIoT.Device.Services.WiFi.AP from 1.0.96.14949 to 1.0.97.55003</br>Bumps nanoFramework.Logging from 1.1.146 to 1.1.147</br>Bumps nanoFramework.System.IO.FileSystem from 1.1.80 to 1.1.81</br>
[version update]

### :warning: This is an automated update. :warning:
