### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Platform.LocalConfig.nuspec
+++ b/MakoIoT.Device.Platform.LocalConfig.nuspec
@@ -41,7 +41,7 @@
       <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.83" />
       <dependency id="nanoFramework.System.IO.Streams" version="1.1.91" />
       <dependency id="nanoFramework.System.Net" version="1.11.37" />
-      <dependency id="nanoFramework.System.Net.Http" version="1.5.189" />
+      <dependency id="nanoFramework.System.Net.Http" version="1.5.192" />
       <dependency id="nanoFramework.System.Text" version="1.3.36" />
       <dependency id="nanoFramework.System.Threading" version="1.1.50" />
     </dependencies>

--- a/Tests/SoftwareTests/MakoIoT.Device.Platform.LocalConfig.Test/MakoIoT.Device.Platform.LocalConfig.Test.nfproj
+++ b/Tests/SoftwareTests/MakoIoT.Device.Platform.LocalConfig.Test/MakoIoT.Device.Platform.LocalConfig.Test.nfproj
@@ -57,8 +57,8 @@
     <Reference Include="System.Net, Version=1.11.37.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\..\packages\nanoFramework.System.Net.1.11.37\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.189.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\..\packages\nanoFramework.System.Net.Http.1.5.189\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.192.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\..\packages\nanoFramework.System.Net.Http.1.5.192\lib\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.50.48563, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\..\packages\nanoFramework.System.Threading.1.1.50\lib\System.Threading.dll</HintPath>

--- a/Tests/SoftwareTests/MakoIoT.Device.Platform.LocalConfig.Test/packages.config
+++ b/Tests/SoftwareTests/MakoIoT.Device.Platform.LocalConfig.Test/packages.config
@@ -5,7 +5,7 @@
   <package id="nanoFramework.System.Collections" version="1.5.63" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.91" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.11.37" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.189" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.192" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.3.36" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.50" targetFramework="netnano1.0" />
   <package id="nanoFramework.TestFramework" version="3.0.73" targetFramework="netnano1.0" developmentDependency="true" />

--- a/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
+++ b/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
@@ -111,8 +111,8 @@
     <Reference Include="System.Net, Version=1.11.37.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Net.1.11.37\lib\System.Net.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=1.5.189.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.189\lib\System.Net.Http.dll</HintPath>
+    <Reference Include="System.Net.Http, Version=1.5.192.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Net.Http.1.5.192\lib\System.Net.Http.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading, Version=1.1.50.48563, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.50\lib\System.Threading.dll</HintPath>

--- a/src/MakoIoT.Device.Platform.LocalConfig/packages.config
+++ b/src/MakoIoT.Device.Platform.LocalConfig/packages.config
@@ -24,7 +24,7 @@
   <package id="nanoFramework.System.IO.FileSystem" version="1.1.83" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.91" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.11.37" targetFramework="netnano1.0" />
-  <package id="nanoFramework.System.Net.Http" version="1.5.189" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Net.Http" version="1.5.192" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Runtime" version="1.0.28" />
   <package id="nanoFramework.System.Text" version="1.3.36" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.50" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps nanoFramework.System.Net.Http from 1.5.189 to 1.5.192</br>
[version update]

### :warning: This is an automated update. :warning:
