### PR TITLE
Update 4 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Platform.LocalConfig.nuspec
+++ b/MakoIoT.Device.Platform.LocalConfig.nuspec
@@ -18,13 +18,13 @@
     <tags>nanoFramework C# csharp netmf netnf mako-iot platform device configuration ap webserver</tags>
     <dependencies>
       <dependency id="MakoIoT.Device.Platform.Interface" version="1.0.27.8561" />
-      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.76.12398" />
+      <dependency id="MakoIoT.Device.Services.Configuration" version="1.0.77.29527" />
       <dependency id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.60.45099" />
       <dependency id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.170.14898" />
-      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.1.17.47275" />
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.55.11594" />
+      <dependency id="MakoIoT.Device.Services.FileStorage" version="1.1.19.62322" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.56.42770" />
       <dependency id="MakoIoT.Device.Services.Mediator" version="1.0.67.23572" />
-      <dependency id="MakoIoT.Device.Services.Server" version="1.0.95.34892" />
+      <dependency id="MakoIoT.Device.Services.Server" version="1.0.96.29786" />
       <dependency id="MakoIoT.Device.Services.WiFi" version="1.0.87.52823" />
       <dependency id="MakoIoT.Device.Services.WiFi.AP" version="1.0.108.20084" />
       <dependency id="MakoIoT.Device.Utilities.Invoker" version="1.0.48.26874" />

--- a/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
+++ b/src/MakoIoT.Device.Platform.LocalConfig/MakoIoT.Device.Platform.LocalConfig.nfproj
@@ -40,7 +40,7 @@
       <HintPath>..\..\packages\MakoIoT.Device.Platform.Interface.1.0.27.8561\lib\MakoIoT.Device.Platform.Interface.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.76.12398\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.1.0.77.29527\lib\MakoIoT.Device.Services.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Configuration.Metadata, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Configuration.Metadata.1.0.60.45099\lib\MakoIoT.Device.Services.Configuration.Metadata.dll</HintPath>
@@ -49,16 +49,16 @@
       <HintPath>..\..\packages\MakoIoT.Device.Services.ConfigurationManager.1.0.170.14898\lib\MakoIoT.Device.Services.ConfigurationManager.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.FileStorage, Version=1.1.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.1.17.47275\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.FileStorage.1.1.19.62322\lib\MakoIoT.Device.Services.FileStorage.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.55.11594\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.56.42770\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Mediator, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.Mediator.1.0.67.23572\lib\MakoIoT.Device.Services.Mediator.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.Server, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.95.34892\lib\MakoIoT.Device.Services.Server.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Server.1.0.96.29786\lib\MakoIoT.Device.Services.Server.dll</HintPath>
     </Reference>
     <Reference Include="MakoIoT.Device.Services.WiFi, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\..\packages\MakoIoT.Device.Services.WiFi.1.0.87.52823\lib\MakoIoT.Device.Services.WiFi.dll</HintPath>

--- a/src/MakoIoT.Device.Platform.LocalConfig/packages.config
+++ b/src/MakoIoT.Device.Platform.LocalConfig/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="MakoIoT.Device.Platform.Interface" version="1.0.27.8561" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Configuration" version="1.0.76.12398" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Configuration" version="1.0.77.29527" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Configuration.Metadata" version="1.0.60.45099" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.ConfigurationManager" version="1.0.170.14898" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.FileStorage" version="1.1.17.47275" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.55.11594" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.FileStorage" version="1.1.19.62322" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.56.42770" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.Mediator" version="1.0.67.23572" targetFramework="netnano1.0" />
-  <package id="MakoIoT.Device.Services.Server" version="1.0.95.34892" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Server" version="1.0.96.29786" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.WiFi" version="1.0.87.52823" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Services.WiFi.AP" version="1.0.108.20084" targetFramework="netnano1.0" />
   <package id="MakoIoT.Device.Utilities.Invoker" version="1.0.48.26874" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Configuration from 1.0.76.12398 to 1.0.77.29527</br>Bumps MakoIoT.Device.Services.FileStorage from 1.1.17.47275 to 1.1.19.62322</br>Bumps MakoIoT.Device.Services.Interface from 1.0.55.11594 to 1.0.56.42770</br>Bumps MakoIoT.Device.Services.Server from 1.0.95.34892 to 1.0.96.29786</br>
[version update]

### :warning: This is an automated update. :warning:
